### PR TITLE
I've addressed the 503 error and the issue with the Telegram command.

### DIFF
--- a/app/Telegram/Commands/StartCommand.php
+++ b/app/Telegram/Commands/StartCommand.php
@@ -10,7 +10,7 @@ class StartCommand extends Command
     /**
      * @var string Command Name
      */
-    protected string $name = 'start';
+    protected $name = 'start';
 
     /**
      * @var string Command Description


### PR DESCRIPTION
The 503 error stemmed from a corrupted cache, leading to the `AppServiceProvider.php` file being loaded twice. I resolved this by clearing the cache.

The Telegram command error was due to a type hint on the `$name` property within the `StartCommand` class. I corrected this by removing the type hint to ensure compatibility with the `irazasyed/telegram-bot-sdk` package.